### PR TITLE
Fix Windows build issues

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,7 +8,10 @@ def build_app():
     is_arm = platform.machine().lower().startswith(('arm', 'aarch'))
     
     # Get PyInstaller path
-    pyinstaller_path = os.path.join(os.path.dirname(sys.executable), 'pyinstaller')
+    if system == 'Windows':
+        pyinstaller_path = os.path.join(os.path.dirname(sys.executable), 'Scripts', 'pyinstaller.exe')
+    else:
+        pyinstaller_path = os.path.join(os.path.dirname(sys.executable), 'pyinstaller')
     
     # Base PyInstaller command
     base_command = [

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,40 +1,40 @@
 @echo off
-echo 🚀 Starting Web2MD build process for Windows...
+echo  Starting Web2MD build process for Windows...
 
 REM Check if conda is installed
 where conda >nul 2>nul
 if %ERRORLEVEL% NEQ 0 (
-    echo ❌ Conda is not installed. Please install Miniconda or Anaconda first.
+    echo  Conda is not installed. Please install Miniconda or Anaconda first.
     exit /b 1
 )
 
 REM Check if the environment exists and remove it if it does
 conda env list | findstr /i "web2md_new" >nul
 if %ERRORLEVEL% EQU 0 (
-    echo 🔄 Removing existing conda environment...
+    echo  Removing existing conda environment...
     call conda env remove -n web2md_new -y
 )
 
 REM Create and activate conda environment
-echo 🔧 Creating new conda environment...
+echo  Creating new conda environment...
 call conda create -n web2md_new python=3.10 -y
 call conda activate web2md_new
 
 REM Install dependencies
-echo 📦 Installing dependencies...
+echo  Installing dependencies...
 pip install -r requirements.txt
 
 REM Run the build script
-echo 🏗️ Building the application...
+echo  Building the application...
 python build.py
 
 REM Check if build was successful
 if exist "dist\Web2MD.exe" (
-    echo ✅ Build successful! The application is in the dist directory.
-    echo 📍 Location: %CD%\dist\Web2MD.exe
+    echo  Build successful! The application is in the dist directory.
+    echo  Location: %CD%\dist\Web2MD.exe
 ) else (
-    echo ❌ Build failed. Please check the error messages above.
+    echo  Build failed. Please check the error messages above.
     exit /b 1
 )
 
-echo 🎉 Build process completed!
+echo  Build process completed!


### PR DESCRIPTION
- Removed emojis from build_windows.bat to fix build failure.
- Corrected build.py to locate pyinstaller.exe under Scripts with .exe extension.

I encountered a build failure on my Windows environment caused by the above reasons. I was able to run the app by fixing as this,  let me send a PR.